### PR TITLE
Fix nmea forwarding bug

### DIFF
--- a/BoardConfig.h
+++ b/BoardConfig.h
@@ -71,10 +71,10 @@
 #define GNSS_TX_PIN    1
 #else // Teensy 4.0 Configuration
 #define GNSS_UBLOXM8N  1       // Set to one if your GNSS is a UBLOX M8N, 0 else. If set to one, GNSS will be automatically configured at startup
-#define GNSS_SERIAL    Serial1
+#define GNSS_SERIAL    Serial2
 #define GNSS_BAUDRATE  9600
-#define GNSS_RX_PIN    0
-#define GNSS_TX_PIN    1
+#define GNSS_RX_PIN    7
+#define GNSS_TX_PIN    8
 #endif
 
 // USB UART params
@@ -88,16 +88,15 @@
 #define WIRED_RX_PIN   34
 #define WIRED_TX_PIN   33
 #else // Teensy 4.0 Configuration
-#define WIRED_NMEA     Serial5
+#define WIRED_NMEA     Serial1
 #define WIRED_BAUDRATE 115200
-#define WIRED_RX_PIN   21
-#define WIRED_TX_PIN   20
+#define WIRED_RX_PIN   0
+#define WIRED_TX_PIN   1
 #endif
 
 // The console to use for menu and NMEA output
 #define CONSOLE  USB_NMEA
-#define NMEA_OUT USB_NMEA
-#define NMEA_IN  USB_NMEA
+#define NMEA_EXT USB_NMEA
 
 // Defines with data comes from which link
 // LINK_NMEA_EXT -> data comes from external NMEA link (WIRED_NMEA)

--- a/DataBridge.cpp
+++ b/DataBridge.cpp
@@ -129,21 +129,30 @@ void DataBridge::PushNmeaChar(char c, LinkId_t sourceLink)
 					if (sourceLink == GNSS_SOURCE_LINK)
 					{
 						DecodeRMCSentence(nmeaBuffer);
-						NMEA_OUT.println(nmeaBuffer);
+						if (sourceLink != LINK_NMEA_EXT)
+						{
+							NMEA_EXT.println(nmeaBuffer);
+						}
 					}
 					break;
 				case NMEA_ID_GGA:
 					if (sourceLink == GNSS_SOURCE_LINK)
 					{
 						DecodeGGASentence(nmeaBuffer);
-						NMEA_OUT.println(nmeaBuffer);
+						if (sourceLink != LINK_NMEA_EXT)
+						{
+							NMEA_EXT.println(nmeaBuffer);
+						}
 					}
 					break;
 				case NMEA_ID_VTG:
 					if (sourceLink == GNSS_SOURCE_LINK)
 					{
 						DecodeVTGSentence(nmeaBuffer);
-						NMEA_OUT.println(nmeaBuffer);
+						if (sourceLink != LINK_NMEA_EXT)
+						{
+							NMEA_EXT.println(nmeaBuffer);
+						}
 					}
 					break;
 				case NMEA_ID_MWV:
@@ -678,7 +687,7 @@ void DataBridge::EncodeMWV_R(NavigationData *micronetData)
 			sprintf(sentence, "$INMWV,%.1f,R,%.1f,N,A", absAwa, gNavData.aws_kt.value);
 			AddNmeaChecksum(sentence);
 			nmeaTimeStamps.vwr = millis();
-			NMEA_OUT.println(sentence);
+			NMEA_EXT.println(sentence);
 		}
 	}
 }
@@ -702,7 +711,7 @@ void DataBridge::EncodeMWV_T(NavigationData *micronetData)
 			sprintf(sentence, "$INMWV,%.1f,T,%.1f,N,A", absTwa, gNavData.tws_kt.value);
 			AddNmeaChecksum(sentence);
 			nmeaTimeStamps.vwt = millis();
-			NMEA_OUT.println(sentence);
+			NMEA_EXT.println(sentence);
 		}
 	}
 }
@@ -722,7 +731,7 @@ void DataBridge::EncodeDPT(NavigationData *micronetData)
 			sprintf(sentence, "$INDPT,%.1f,0.0", gNavData.dpt_m.value);
 			AddNmeaChecksum(sentence);
 			nmeaTimeStamps.dpt = millis();
-			NMEA_OUT.println(sentence);
+			NMEA_EXT.println(sentence);
 		}
 	}
 }
@@ -742,7 +751,7 @@ void DataBridge::EncodeMTW(NavigationData *micronetData)
 			sprintf(sentence, "$INMTW,%.1f,C", gNavData.stp_degc.value);
 			AddNmeaChecksum(sentence);
 			nmeaTimeStamps.mtw = millis();
-			NMEA_OUT.println(sentence);
+			NMEA_EXT.println(sentence);
 		}
 	}
 }
@@ -763,7 +772,7 @@ void DataBridge::EncodeVLW(NavigationData *micronetData)
 			sprintf(sentence, "$INVLW,%.1f,N,%.1f,N", gNavData.log_nm.value, gNavData.trip_nm.value);
 			AddNmeaChecksum(sentence);
 			nmeaTimeStamps.vlw = millis();
-			NMEA_OUT.println(sentence);
+			NMEA_EXT.println(sentence);
 		}
 	}
 }
@@ -795,7 +804,7 @@ void DataBridge::EncodeVHW(NavigationData *micronetData)
 			}
 			AddNmeaChecksum(sentence);
 			nmeaTimeStamps.vhw = millis();
-			NMEA_OUT.println(sentence);
+			NMEA_EXT.println(sentence);
 		}
 	}
 }
@@ -815,7 +824,7 @@ void DataBridge::EncodeHDG(NavigationData *micronetData)
 			sprintf(sentence, "$INHDG,%.0f,,,,", gNavData.hdg_deg.value + gConfiguration.headingOffset_deg);
 			AddNmeaChecksum(sentence);
 			nmeaTimeStamps.hdg = millis();
-			NMEA_OUT.println(sentence);
+			NMEA_EXT.println(sentence);
 		}
 	}
 }
@@ -835,7 +844,7 @@ void DataBridge::EncodeXDR(NavigationData *micronetData)
 			sprintf(sentence, "$INXDR,U,%.1f,V,BATTERY#0", gNavData.vcc_v.value);
 			AddNmeaChecksum(sentence);
 			nmeaTimeStamps.vcc = millis();
-			NMEA_OUT.println(sentence);
+			NMEA_EXT.println(sentence);
 		}
 	}
 }

--- a/MicronetToNMEA.ino
+++ b/MicronetToNMEA.ino
@@ -665,10 +665,10 @@ void MenuConvertToNmea()
 		}
 
 		char c;
-		while (NMEA_IN.available() > 0)
+		while (NMEA_EXT.available() > 0)
 		{
-			c = NMEA_IN.read();
-			if ((CONSOLE == NMEA_IN) && (c == 0x1b))
+			c = NMEA_EXT.read();
+			if ((CONSOLE == NMEA_EXT) && (c == 0x1b))
 			{
 				CONSOLE.println("ESC key pressed, stopping conversion.");
 				exitNmeaLoop = true;
@@ -688,7 +688,7 @@ void MenuConvertToNmea()
 			}
 		}
 
-		if (CONSOLE != NMEA_IN)
+		if (CONSOLE != NMEA_EXT)
 		{
 			while (CONSOLE.available() > 0)
 			{

--- a/doc/user_manual/user_manual.md
+++ b/doc/user_manual/user_manual.md
@@ -253,15 +253,14 @@ and their meaning.
 | GNSS\_BAUDRATE            | Defines GNSS UART default baud-rate                                                                                                                                                |
 | GNSS\_RX\_PIN             | Defines serial RX pin connected to NMEA GNSS TX pin                                                                                                                                |
 | GNSS\_TX\_PIN             | Defines serial TX pin connected to NMEA GNSS RX pin                                                                                                                                |
-| USB\_NMEA                 | Defines which serial port is connected to USB serial converter                                                                                                                     |
+| USB\_NMEA                 | Defines which serial port is connected to the USB NMEA connection                                                                                                                  |
 | USB\_BAUDRATE             | Defines baud rate of USB serial converter                                                                                                                                          |
 | WIRED\_NMEA               | Defines which serial port is connected to the wired NMEA connection                                                                                                                |
 | WIRED\_BAUDRATE           | Defines baud rate of the wired NMEA connection                                                                                                                                     |
 | WIRED\_RX\_PIN            | Defines serial RX pin used for wired NMEA                                                                                                                                          |
 | WIRED\_TX\_PIN            | Defines serial TX pin used for wired NMEA                                                                                                                                          |
-| CONSOLE                   | Defines on which serial port is displayed the console (can be USB\_CONSOLE or WIRED\_SERIAL). Can be on the same serial link than NMEA\_IN and NMEA\_OUT                           |
-| NMEA\_OUT                 | Defines on which serial port to output NMEA stream. (can be USB\_CONSOLE or WIRED\_SERIAL). Can be on the same serial link than CONSOLE and NMEA\_IN.                              |
-| NMEA\_IN                  | Defines on which serial port to read input NMEA stream. (can be USB\_CONSOLE or WIRED\_SERIAL). Can be on the same serial link than CONSOLE and NMEA\_OUT.                         |
+| CONSOLE                   | Defines on which serial port is displayed the console (can be USB\_NMEA or WIRED\_NMEA). Can be on the same serial link than NMEA\_EXT                                             |
+| NMEA\_EXT                 | Defines to which serial port is connected the external NMEA stream. (can be USB\_NMEA or WIRED\_NMEA). Can be on the same serial link than CONSOLE and NMEA\_IN.                   |
 | NAV\_SOURCE\_LINK         | Defines where navigation data is coming from (related to RMB sentences). See Section <span>[5.1.6](#supportednmeasentences)</span> for more details on possible values.            |
 | GNSS\_SOURCE\_LINK        | Defines where positioning data is coming from (related to RMC, GGA, VTG sentences). See Section <span>[5.1.6](#supportednmeasentences)</span> for more details on possible values. |
 | WIND\_SOURCE\_LINK        | Defines where wind data is coming from (related to MWV sentence). See Section <span>[5.1.6](#supportednmeasentences)</span> for more details on possible values.                   |
@@ -611,38 +610,41 @@ value in EEPROM. Your compass is calibrated.
 
 Menu *"4 - Start NMEA conversion"* actually start Micronet/NMEA
 conversion as suggested by the name. Once you enter in this mode
-MicronetToNMEA will output NMEA sentences to the NMEA\_OUT link. By
-default, NMEA\_OUT is routed to the same serial link than the console
+MicronetToNMEA will output NMEA sentences to the NMEA\_EXT link. By
+default, NMEA\_EXT is routed to the same serial link than the console
 (USB serial). It means that you will immediately see NMEA sentences
-beeing written onto console. More silently, MicronetToNMEA also decodes
-any incoming NMEA sentence from NMEA\_IN serial (the same than NMEA\_OUT
-and CONSOLE by default) and transmits it to your Micronet network. You
-need to be in this mode to see decoded GNSS or NMEA data displayed onto
-your Micronet displays. You also need to be in this mode for the
-configuration parameters modified onto your Micronet displays to be
-memorized by MicronetToNMEA (e.g. speed factor, sounder offset, etc.).
-If attached to a network, MicronetToNMEA will automatically switch to
-this mode when powered-up. You can leave by just pressing *\<ESC\>* in
-the console.  
+beeing written onto console. Additionnaly, MicronetToNMEA also decodes
+any incoming NMEA sentence from NMEA\_EXT serial and transmits it to
+your Micronet network. You need to be in this mode to see decoded GNSS
+or NMEA data displayed onto your Micronet displays. You also need to be
+in this mode for the configuration parameters modified onto your
+Micronet displays to be memorized by MicronetToNMEA (e.g. speed factor,
+sounder offset, etc.). If attached to a network, MicronetToNMEA will
+automatically switch to this mode when powered-up. You can leave it by
+just pressing *\<ESC\>* in the console.  
   
-Here is a summary of all actions realized by MicronetToNMEA in this mode
-:
+Here is a summary of all actions realized by MicronetToNMEA in this
+mode, with the default configuration :
 
   - Collect and decode NMEA sentences from GNSS\_NMEA link
 
-  - Collect and decode NMEA sentences from NMEA\_IN link
+  - Collect and decode NMEA sentences from NMEA\_EXT link
 
-  - Forward NMEA sentences from GNSS\_NMEA link to NMEA\_OUT link
+  - Forward NMEA sentences from GNSS\_NMEA link to NMEA\_EXT link
 
   - Collect and decode data from Micronet devices
 
   - Send all data collected from NMEA links to Micronet network
 
-  - Send all data collected from Micronet devices to NMEA\_OUT link
+  - Send all data collected from Micronet devices to NMEA\_EXT link
 
   - Calculate heading from LSM303DLH(C), if any
 
-  - Send heading data to Micronet network and NMEA\_OUT link
+  - Send heading data to Micronet network and NMEA\_EXT link
+
+It is important to note that the configuration can change this sequence
+and the way MicronetToNMEA decodes/forwards data. See chapter
+<span>[5.1.6](#supportednmeasentences)</span> for more details.
 
 ### NMEA sentences and data flow
 

--- a/doc/user_manual/user_manual.tex
+++ b/doc/user_manual/user_manual.tex
@@ -177,7 +177,7 @@ By default, MicronetToNMEA is configured for a specific HW layout. This means th
 		\hline
 		GNSS\_TX\_PIN & Defines serial TX pin connected to NMEA GNSS RX pin\\
 		\hline
-		USB\_NMEA & Defines which serial port is connected to USB serial converter\\
+		USB\_NMEA & Defines which serial port is connected to the USB NMEA connection\\
 		\hline
 		USB\_BAUDRATE & Defines baud rate of USB serial converter\\
 		\hline
@@ -189,11 +189,9 @@ By default, MicronetToNMEA is configured for a specific HW layout. This means th
 		\hline
 		WIRED\_TX\_PIN & Defines serial TX pin used for wired NMEA\\
 		\hline
-		CONSOLE & Defines on which serial port is displayed the console (can be USB\_CONSOLE or WIRED\_SERIAL). Can be on the same serial link than NMEA\_IN and NMEA\_OUT\\
+		CONSOLE & Defines on which serial port is displayed the console (can be USB\_NMEA or WIRED\_NMEA). Can be on the same serial link than NMEA\_EXT\\
 		\hline
-		NMEA\_OUT & Defines on which serial port to output NMEA stream. (can be USB\_CONSOLE or WIRED\_SERIAL). Can be on the same serial link than CONSOLE and NMEA\_IN.\\
-		\hline
-		NMEA\_IN & Defines on which serial port to read input NMEA stream. (can be USB\_CONSOLE or WIRED\_SERIAL). Can be on the same serial link than CONSOLE and NMEA\_OUT.\\
+		NMEA\_EXT & Defines to which serial port is connected the external NMEA stream. (can be USB\_NMEA or WIRED\_NMEA). Can be on the same serial link than CONSOLE and NMEA\_IN.\\
 		\hline
 		NAV\_SOURCE\_LINK & Defines where navigation data is coming from (related to RMB sentences). See Section {\ref{supportednmeasentences}} for more details on possible values.\\
 		\hline
@@ -435,22 +433,24 @@ Once achieved, just press \emph{<ESC>} and tell MicronetToNMEA to save the value
 
 \subsection{Starting NMEA conversion}
 
-Menu \emph{"4 - Start NMEA conversion"} actually start Micronet/NMEA conversion as suggested by the name. Once you enter in this mode MicronetToNMEA will output NMEA sentences to the NMEA\_OUT link. By default, NMEA\_OUT is routed to the same serial link than the console (USB serial). It means that you will immediately see NMEA sentences beeing written onto console. More silently, MicronetToNMEA also decodes any incoming NMEA sentence from NMEA\_IN serial (the same than NMEA\_OUT and CONSOLE by default) and transmits it to your Micronet network.
+Menu \emph{"4 - Start NMEA conversion"} actually start Micronet/NMEA conversion as suggested by the name. Once you enter in this mode MicronetToNMEA will output NMEA sentences to the NMEA\_EXT link. By default, NMEA\_EXT is routed to the same serial link than the console (USB serial). It means that you will immediately see NMEA sentences beeing written onto console. Additionnaly, MicronetToNMEA also decodes any incoming NMEA sentence from NMEA\_EXT serial and transmits it to your Micronet network.
 You need to be in this mode to see decoded GNSS or NMEA data displayed onto your Micronet displays. You also need to be in this mode for the configuration parameters modified onto your Micronet displays to be memorized by MicronetToNMEA (e.g. speed factor, sounder offset, etc.).
-If attached to a network, MicronetToNMEA will automatically switch to this mode when powered-up. You can leave by just pressing \emph{<ESC>} in the console.
+If attached to a network, MicronetToNMEA will automatically switch to this mode when powered-up. You can leave it by just pressing \emph{<ESC>} in the console.
 \\
 \\
-Here is a summary of all actions realized by MicronetToNMEA in this mode :
+Here is a summary of all actions realized by MicronetToNMEA in this mode, with the default configuration :
 \begin{itemize}
 	\item Collect and decode NMEA sentences from GNSS\_NMEA link
-	\item Collect and decode NMEA sentences from NMEA\_IN link
-	\item Forward NMEA sentences from GNSS\_NMEA link to NMEA\_OUT link
+	\item Collect and decode NMEA sentences from NMEA\_EXT link
+	\item Forward NMEA sentences from GNSS\_NMEA link to NMEA\_EXT link
 	\item Collect and decode data from Micronet devices
 	\item Send all data collected from NMEA links to Micronet network
-	\item Send all data collected from Micronet devices to NMEA\_OUT link
+	\item Send all data collected from Micronet devices to NMEA\_EXT link
 	\item Calculate heading from LSM303DLH(C), if any
-	\item Send heading data to Micronet network and NMEA\_OUT link
+	\item Send heading data to Micronet network and NMEA\_EXT link
 \end{itemize}
+
+It is important to note that the configuration can change this sequence and the way MicronetToNMEA decodes/forwards data. See chapter {\ref{supportednmeasentences}} for more details.
 
 \subsection{NMEA sentences and data flow}\label{supportednmeasentences}
 


### PR DESCRIPTION
It has been discovered that MTN was forwarding GNSS data receive from NMEA_EXT to NMEA_EXT, causing instability of boat's position in OpenCPN. This pull request fixes it.
I also cleaned up a bit BoardConfig.h.