### PR TITLE
Fast isr

### DIFF
--- a/CC1101Driver.cpp
+++ b/CC1101Driver.cpp
@@ -312,14 +312,14 @@ void CC1101Driver::WriteTxFifo(uint8_t data)
 	SpiWriteReg(CC1101_TXFIFO, data);
 }
 
-void CC1101Driver::DeIrqOnTxFifoEmpty()
+void CC1101Driver::IrqOnTxFifoUnderflow()
 {
 	SpiWriteReg(CC1101_IOCFG0, 0x05);
 }
 
-void CC1101Driver::IrqOnTxFifoLow()
+void CC1101Driver::IrqOnTxFifoThreshold()
 {
-	SpiWriteReg(CC1101_IOCFG0, 0x43);
+	SpiWriteReg(CC1101_IOCFG0, 0x42);
 }
 
 void CC1101Driver::IrqOnRxFifoThreshold()

--- a/CC1101Driver.h
+++ b/CC1101Driver.h
@@ -116,7 +116,7 @@
 #define CC1101_RXFIFO       0x3F
 
 #define CC1101_RXFIFOTHR_16 0x03
-#define CC1101_TXFIFOTHR_17 0x0B
+#define CC1101_TXFIFOTHR_9  0x0D
 
 //************************************* class **************************************************//
 class CC1101Driver
@@ -147,8 +147,8 @@ public:
 	int GetTxFifoLevel();
 	void ReadRxFifo(uint8_t *buffer, int nbBytes);
 	void WriteTxFifo(uint8_t data);
-	void DeIrqOnTxFifoEmpty();
-	void IrqOnTxFifoLow();
+	void IrqOnTxFifoUnderflow();
+	void IrqOnTxFifoThreshold();
 	void IrqOnRxFifoThreshold();
 	void SetFifoThreshold(uint8_t fifoThreshold);
 	void FlushRxFifo();

--- a/DataBridge.cpp
+++ b/DataBridge.cpp
@@ -334,7 +334,8 @@ void DataBridge::DecodeRMBSentence(char *sentence)
 	{
 		// We look for WP1 ID (target)
 		uint8_t c;
-		for (uint32_t i = 0; i < sizeof(gNavData.waypoint.name); i++)
+		uint32_t i;
+		for (i = 0; i < sizeof(gNavData.waypoint.name); i++)
 		{
 			if (sentence[i] != ',')
 			{
@@ -356,6 +357,7 @@ void DataBridge::DecodeRMBSentence(char *sentence)
 				break;
 			}
 		}
+		gNavData.waypoint.nameLength = i;
 	}
 #if (INVERTED_RMB_WORKAROUND != 1)
 	for (int i = 0; i < 5; i++)

--- a/MicronetCodec.h
+++ b/MicronetCodec.h
@@ -139,7 +139,7 @@ private:
 	uint8_t Add16bitField(uint8_t *buffer, uint8_t fieldCode, int16_t value);
 	uint8_t AddDual16bitField(uint8_t *buffer, uint8_t fieldCode, int16_t value1, int16_t value2);
 	uint8_t AddQuad8bitField(uint8_t *buffer, uint8_t fieldCode, uint8_t value1, uint8_t value2, uint8_t value3, uint8_t value4);
-	uint8_t Add16bitAndSix8bitField(uint8_t *buffer, uint8_t fieldCode, int16_t value1, uint8_t *wpname);
+	uint8_t Add16bitAndSix8bitField(uint8_t *buffer, uint8_t fieldCode, int16_t value1, uint8_t *wpname, uint8_t WPnameLength);
 	uint8_t Add24bitField(uint8_t *buffer, uint8_t fieldCode, int32_t value);
 	uint8_t Add32bitField(uint8_t *buffer, uint8_t fieldCode, int32_t value);
 };

--- a/MicronetToNMEA.ino
+++ b/MicronetToNMEA.ino
@@ -205,7 +205,7 @@ void setup()
 
 	// Attach callback to GDO0 pin
 	// According to CC1101 configuration this callback will be executed when CC1101 will have detected Micronet's sync word
-	attachInterrupt(digitalPinToInterrupt(GDO0_PIN), RfIsr, RISING);
+	attachInterrupt(digitalPinToInterrupt(GDO0_PIN), RfIsr, HIGH);
 
 	// Display serial menu
 	gMenuManager.PrintMenu();

--- a/NavigationData.h
+++ b/NavigationData.h
@@ -71,7 +71,8 @@ typedef struct
 typedef struct
 {
 	bool valid;
-	uint8_t name[8];
+	uint8_t name[16];
+	uint8_t nameLength;
 	uint32_t timeStamp;
 } WaypointName_t;
 

--- a/RfDriver.h
+++ b/RfDriver.h
@@ -18,7 +18,8 @@ typedef enum {
 	RF_STATE_RX_WAIT_SYNC = 0,
 	RF_STATE_RX_HEADER,
 	RF_STATE_RX_PAYLOAD,
-	RF_STATE_TX_TRANSMIT
+	RF_STATE_TX_TRANSMIT,
+	RF_STATE_TX_LAST_TRANSMIT
 } RfDriverState_t;
 
 class RfDriver
@@ -52,6 +53,9 @@ private:
 	int GetNextTransmitIndex();
 	int GetFreeTransmitSlot();
 	void TransmitCallback();
+	void GDO0RXCallback();
+	void GDO0TXCallback();
+
 	static void TimerHandler();
 	static RfDriver *rfDriver;
 };


### PR DESCRIPTION
CC1101 ISR is polling FIFO status on SPI bus during all the time of RF packet RX/TX. It blocks other IRQs for several milliseconds leading to loss of NMEA data on serial link. This pull request modify CC1101 ISR to use FIFO related IRQ to avoid polling for FIFO status in the ISR.
There is no more NMEA data loss now.
